### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,12 @@ language: php
 php:
   - 7.0
   - 7.1
+  - 7.2
+  - nightly
+
+matrix:
+  allow_failures:
+    - php: nightly
 
 install:
   - composer install --prefer-dist

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,6 @@
     "require": {
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7.0"
+        "phpunit/phpunit": "^6.5"
     }
 }

--- a/tests/WithTest.php
+++ b/tests/WithTest.php
@@ -3,10 +3,11 @@
 namespace Ahc\With\Test;
 
 use Ahc\With\With;
+use PHPUnit\Framework\TestCase;
 use function Ahc\with;
 
 /** @coversDefaultClass \Ahc\With\With */
-class WithTest extends \PHPUnit_Framework_TestCase
+class WithTest extends TestCase
 {
     public function testWith()
     {


### PR DESCRIPTION
# Changed log
- Add the `php-nightly` test and allow this test failure in Travis CI build.
- Upgrade the PHPUnit version to support the `php-7.x` versions.
- Using the class-based PHPUnit namespace.